### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 thiserror = "1.0"
-derive_builder = "0.9"
+derive_builder = "0.12"
 reqwest = "0.11"
-sha1 = "0.6"
+sha1_smol = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, Cursor};
 use reqwest;
 use reqwest::{Response, StatusCode};
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
-use sha1::{Sha1};
+use sha1_smol::{Sha1};
 use serde_json::{from_str};
 use derive_builder::Builder;
 


### PR DESCRIPTION
I noticed that derive_builder used `String` for the `Result` error, which doesn't implement `std::error::Error`. With the update to version 0.12 derive_builder will automatically create an error type for the builder instead.

I also switched sha1 to sha1_smol as per [this note](https://docs.rs/sha1/latest/sha1/#note-for-users-of-sha1-v06).